### PR TITLE
Opzet voor paginalay-out en navigatie op mobiel en desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin-release/
 
 # Hugo
 public/
+resources/_gen
 
 # Backup Files
 *.markdown~
@@ -67,3 +68,6 @@ bower_components
 # AWS stuff for publishing static files
 .aws-credentials.json
 .awspublish*
+
+# Workspace stuff
+.idea

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,0 +1,25 @@
+const toggleMenu = document.querySelector('.toggle-menu');
+const mainNav = document.querySelector('#main-nav');
+
+
+function toggleMenuHandler(event) {
+  if (mainNav.classList.contains('__open')) {
+    mainNav.classList.remove('__open');
+    toggleMenu.setAttribute('aria-expanded', 'false');
+    toggleMenu.innerText = 'menu';
+  } else {
+    mainNav.classList.add('__open');
+    mainNav.querySelector('a[href="/"]').focus();
+    toggleMenu.setAttribute('aria-expanded', 'true');
+    toggleMenu.innerText = 'sluiten';
+  }
+  event.target.blur();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.documentElement.classList.add('js');
+  toggleMenu.setAttribute('aria-controls', 'main-nav');
+  toggleMenu.setAttribute('aria-expanded', 'false');
+})
+
+toggleMenu.addEventListener('click', toggleMenuHandler)

--- a/assets/scss/base.scss
+++ b/assets/scss/base.scss
@@ -1,0 +1,21 @@
+html {
+	font-size: 1.25rem;
+}
+
+:is(*, ::before, ::after) {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+}
+
+:is(ul, ol) {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+:is(h1, h2, h3, h4, h5, h6, p) {
+	margin: 0
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,43 +1,207 @@
-$paradise-pink: #EA1F4B;
-$paradise-pink-light: #EF5778;
+@import "variables";
+@import "base";
 
-html {
-  font-size: 62.5%;
-}
+$tablet: 768px;
 
 body {
-  font-size: 1.6rem;
-  line-height: 1.3;
+	--top-offset: 60px; // hoogte van de header
+	--bottom-offset: 8px; // afstand tot onderkant scherm
+	--tablet: 768px;
+
+	font-family: var(--font-family);
+	font-size: 0.8rem;
+
+	@media (min-width: 768px) {
+		font-size: 1rem;
+	}
 }
 
-h2, h3, h4, h5, h6 {
-  margin: 3.8rem 0 .6rem;
+.page-wrapper {
+
+	@media (min-width: $tablet) {
+		display: grid;
+		grid-template-columns: 250px 1fr;
+		grid-template-rows: auto 1fr;
+
+		header {
+			grid-column: 1 / span 2;
+			grid-row: 1;
+		}
+
+		nav {
+			grid-column: 1 / 2;
+			grid-row: 2;
+		}
+
+		main {
+			grid-column: 2 / 3;
+			grid-row: 2;
+		}
+	}
 }
 
-h1 {
-  font-size: 3.2rem;
+
+
+
+.page-header {
+	align-items: center;
+	background-color: var(--bg-grey);
+	block-size: 60px;
+	inline-size: 100%;
+	padding: 8px 8px 16px;
+
+	h1 {
+		a {
+			color: inherit;
+			text-decoration: none;
+		}
+	}
 }
 
-h2 {
-  font-size: 2.5rem;
+.js .page-header {
+	position: fixed;
+	top: 0;
+	z-index: 2;
+
+	@media (min-width: $tablet) {
+		position: static;
+	}
 }
 
-p, ul, ol {
-  font-size: 1.8rem;
-  margin: 0 0 .8em;
+.toggle-container {
+	display: none;
 }
 
-a {
-  text-decoration: none;
-  color: $paradise-pink;
+.js .toggle-container {
+	align-items: center;
+	display: flex;
+	inline-size: 100%;
+	justify-content: center;
+	padding-block: 8px;
+	position: fixed;
+	left: 0;
+	bottom: 0;
 
-  &:hover {
-    color: $paradise-pink-light;
-  }
+	@media (min-width: $tablet) {
+		display: none;
+	}
 }
 
-article {
-  padding: 2rem 1rem;
-  max-width: calc(44em + 2rem);
-  margin: 0 auto;
+.toggle-menu {
+	background-color: var(--accent-color);
+	border: none;
+	border-radius: 4px;
+	color: white;
+	display: inline-block;
+	font-size: 1.25rem;
+	font-variant: all-small-caps;
+	font-weight: bold;
+	padding: 8px;
+	transition: all 200ms ease-in-out;
+
+	&:hover {
+		background-color: transparent;
+		color: var(--accent-color);
+		outline: 2px solid var(--accent-color);
+	}
 }
+
+.js nav {
+	background-color: var(--bg-grey);
+	position: fixed;
+	left: 0;
+	right: 0;
+	top: var(--top-offset);
+	bottom: 0;
+	transform: translateX(-100%);
+	transition: transform 200ms ease-in-out, visibility linear 200ms;
+	visibility: hidden;
+	z-index: 1;
+
+	&.__open {
+		transform: translateX(0);
+		visibility: visible;
+	}
+}
+
+:is(nav, .js nav) {
+	@media (min-width: $tablet) {
+		padding-block-start: 20px;
+		position: static;
+		transform: translateX(0);
+		visibility: visible;
+
+		ul {
+			display: grid;
+			flex-flow: column wrap;
+		}
+
+		li {
+			flex: 0;
+		}
+	}
+}
+
+ul {
+	align-content: flex-start;
+	align-items: center;
+	display: flex;
+	flex-flow: row wrap;
+	gap: 1rem;
+	justify-content: center;
+}
+
+.js li {
+	inline-size: 100%;
+}
+
+li {
+	text-align: center;
+
+	a {
+		animation: border-radius 200ms;
+		background-color: var(--bg-light-grey);
+		border-top-right-radius: 30px;
+		color: inherit;
+		display: inline-block;
+		padding: 0.5rem;
+		text-decoration: none;
+		transition: background-color 200ms ease-in-out, border-radius 400ms ease-in 100ms;
+
+		&.__smaller {
+			font-size: smaller;
+		}
+
+		&:is(:hover, :active) {
+			background-color: var(--accent-color);
+			border-bottom-left-radius: 30px;
+			border-top-right-radius: 0;
+			color: white;
+		}
+	}
+}
+
+
+main {
+	align-items: start;
+	display: grid;
+	min-block-size: 100dvh;
+	grid-template-columns: repeat(12, 1fr);
+	grid-auto-rows: max-content;
+	padding: 1rem 8px;
+
+	h2 {
+		grid-column: 1 / -1;
+	}
+
+
+}
+
+.js main {
+	margin-block-start: var(--top-offset);
+
+	@media (min-width: $tablet) {
+		margin-block-start: 0;
+	}
+}
+

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -1,0 +1,9 @@
+:root {
+	--font-family: sans-serif;
+	--accent-color: hsl(89deg 53% 57%);
+	--bg-light-accent: hsl(89deg 53% 85%);
+	--bg-grey: hsl(0deg 0% 90%);
+	--bg-light-grey: hsl(210deg 12% 97%);
+
+}
+

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,11 @@
+---
+title: Home
+---
+
+## Home page content
+
+Dit is de main content. Hier komen de kaarten met de tekeningen.
+
+
+
+

--- a/content/mijn-werk/_index.md
+++ b/content/mijn-werk/_index.md
@@ -1,0 +1,7 @@
+---
+title: Mijn werk
+---
+
+## Mijn werk
+
+Hier komt mijn werk.

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,3 @@
 baseURL = 'https://example.org/'
 languageCode = 'en-us'
-title = 'My New Hugo Site'
+title = 'Sara-Li tekent'

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="nl">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -13,4 +13,6 @@
   <body>
     {{ block "page" . }}{{ end }}
   </body>
+{{ $script := resources.Get "js/script.js" | minify }}
+  <script src="{{ $script.RelPermalink }}"></script>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,26 +1,32 @@
 {{ define "page" }}
-<article class="container">
-  {{ if ne .Kind "home" }}
-  <a href="{{ .Site.Home.RelPermalink }}">Home</a>
-  {{ end }}
-  <h1>{{ .Title }}</h1>
-  {{ range .Sections }}
-  <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
-  <ul>
-    {{ range .Pages }}
-    <li>
-      <a href="{{ .RelPermalink }}">{{ or .Title .RelPermalink }}</a>
-    </li>
-    {{ end }}
-  </ul>
-  {{ end }}
-  <h2>Other</h2>
-  <ul>
-    {{ range .RegularPages }}
-    <li>
-      <a href="{{ .RelPermalink }}">{{ or .Title .RelPermalink }}</a>
-    </li>
-    {{ end }}
-  </ul>
-</article>
+<div class="page-wrapper">
+  {{ partial "header.html" . }}
+  <main>
+    {{ .Content }}
+  </main>
+<!--<article class="container">-->
+<!--  {{ if ne .Kind "home" }}-->
+<!--  <a href="{{ .Site.Home.RelPermalink }}">Home</a>-->
+<!--  {{ end }}-->
+<!--  <h1>{{ .Title }}</h1>-->
+<!--  {{ range .Sections }}-->
+<!--  <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>-->
+<!--  <ul>-->
+<!--    {{ range .Pages }}-->
+<!--    <li>-->
+<!--      <a href="{{ .RelPermalink }}">{{ or .Title .RelPermalink }}</a>-->
+<!--    </li>-->
+<!--    {{ end }}-->
+<!--  </ul>-->
+<!--  {{ end }}-->
+<!--  <h2>Other</h2>-->
+<!--  <ul>-->
+<!--    {{ range .RegularPages }}-->
+<!--    <li>-->
+<!--      <a href="{{ .RelPermalink }}">{{ or .Title .RelPermalink }}</a>-->
+<!--    </li>-->
+<!--    {{ end }}-->
+<!--  </ul>-->
+<!--</article>-->
+</div>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,9 @@
-{{ define "page" }}
-<article class="container">
-  <a href="{{ .CurrentSection.RelPermalink }}"
-    >Back to {{ .CurrentSection.Title }}</a
-  >
-  <h1>{{ .Title }}</h1>
-  {{ .Content }}
-</article>
-{{ end }}
+<!--{{ define "page" }}-->
+<!--<article class="container">-->
+<!--  <a href="{{ .CurrentSection.RelPermalink }}"-->
+<!--    >Back to {{ .CurrentSection.Title }}</a-->
+<!--  >-->
+<!--  <h1>{{ .Title }}</h1>-->
+<!--  {{ .Content }}-->
+<!--</article>-->
+<!--{{ end }}-->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,27 @@
+<header class="page-header">
+  <h1><a href="{{ .RelPermalink }}">{{ .Site.Title }}</a></h1>
+  <div class="toggle-container">
+    <button class="toggle-menu">
+      Menu
+    </button>
+  </div>
+</header>
+  <nav id="main-nav" aria-label="primair" tabindex="-1">
+    <ul>
+      <li>
+        <a href="/">Home</a>
+      </li>
+      <li>
+        <a href="/mijn-werk">Mijn werk</a>
+      </li>
+      <li>
+        <a href="/" class="__smaller">Karikaturen</a>
+      </li>
+      <li>
+        <a href="/" class="__smaller">Persoonlijk werk</a>
+      </li>
+      <li>
+        <a href="/">Commission aanvragen</a>
+      </li>
+    </ul>
+  </nav>


### PR DESCRIPTION
Zonder JS is menu altijd zichtbaar.
Met JS is er een toggle en worden aria-attributen gebruikt voor betere toegankelijkheid. Testen in DevTools met Shift+Control+P, typ java, kies JS inschakelen/uitschakelen
Op mobiel is er 1 kolom.
Vanaf 768px is er een 12-koloms grid om de kaarten te kunnen verdelen.

Volgende stap: lay-out voor de kaarten.